### PR TITLE
Added hostname and check name to summary alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Changed
 - Updated travis, goreleaser configurations.
 - Updated license.
+- Added hostname and check name to summary alert
 
 ### Removed
 - Removed redundant post deploy scripts for travis.

--- a/main.go
+++ b/main.go
@@ -92,11 +92,13 @@ func manageIncident(event *types.Event) error {
 		severity = severities[event.Check.Status]
 	}
 
+	summary := fmt.Sprintf("%s/%s : %s", event.Entity.Name, event.Check.Name, event.Check.Output)
+
 	pdPayload := pagerduty.V2Payload{
 		Source:    event.Entity.Name,
 		Component: event.Check.Name,
 		Severity:  severity,
-		Summary:   event.Check.Output,
+		Summary:   summary,
 		Details:   event,
 	}
 


### PR DESCRIPTION
With this fix the alerts are eligible in the pagerduty dashboard, like the old version