### PR TITLE
Remove extra comma for valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Example Sensu Go handler definition:
         "type": "pipe",
         "command": "sensu-pagerduty-handler",
         "env_vars": [
-          "PAGERDUTY_TOKEN=SECRET",
+          "PAGERDUTY_TOKEN=SECRET"
         ],
         "timeout": 10,
         "filters": [


### PR DESCRIPTION
As it stands, this is not valid JSON. Users that go to copy the example from the readme or on Bonsai will end up with an error.