### PR TITLE
Dedup key & severity mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+sensu-pagerduty-handler
 *.exe
 *.exe~
 *.dll
@@ -17,3 +18,6 @@ vendor/
 # deploy
 bonsai/
 dist/
+
+# IDE's
+.idea/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -30,6 +30,14 @@
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
@@ -111,6 +119,14 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   digest = "1:dbfe572cc258e5bcf54cb650a06d90edd0da04e42ca1ed909cc1d49f00011c63"
   name = "github.com/robertkrimen/otto"
@@ -173,6 +189,14 @@
   pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = "UT"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   branch = "master"
@@ -288,6 +312,7 @@
     "github.com/sensu/sensu-go/api/core/v2",
     "github.com/sensu/sensu-plugins-go-library/sensu",
     "github.com/sensu/sensu-plugins-go-library/templates",
+    "github.com/stretchr/testify/assert",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -147,15 +147,16 @@
   version = "5.9.0"
 
 [[projects]]
-  digest = "1:8cd72fbcf8f18cf753ca9c40723eaef3356e166437f33d219d977581b7024d14"
+  digest = "1:7897f5d213d0e18a7ce2e217bcf62db98f21ac99b837ca5bc912ccf4f54fd468"
   name = "github.com/sensu/sensu-plugins-go-library"
   packages = [
     "args",
     "sensu",
+    "templates",
   ]
   pruneopts = "UT"
-  revision = "a4d9fcd58e069a1c9e51984b9f4b466accd366c8"
-  version = "0.2.0"
+  revision = "3ea0d273e45847a43108b9025fe0d65be86463a2"
+  version = "0.3.0"
 
 [[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
@@ -286,6 +287,7 @@
     "github.com/PagerDuty/go-pagerduty",
     "github.com/sensu/sensu-go/api/core/v2",
     "github.com/sensu/sensu-plugins-go-library/sensu",
+    "github.com/sensu/sensu-plugins-go-library/templates",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,6 +37,10 @@
   name = "github.com/sensu/sensu-plugins-go-library"
   version = "0.3.0"
 
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.3.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/sensu/sensu-plugins-go-library"
-  version = "0.2.0"
+  version = "0.3.0"
 
 [prune]
   go-tests = true

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Example Sensu Go handler definition:
         "command": "sensu-pagerduty-handler",
         "env_vars": [
           "PAGERDUTY_TOKEN=SECRET",
-          "PAGERDUTY_DEDUP_KEY",
-          "PAGERDUTY_STATUS_MAP"
+          "PAGERDUTY_DEDUP_KEY=SENSU_EVENT_LABEL",
+          "PAGERDUTY_DEDUP_KEY_TEMPLATE={{.Entity.Name}}-{{.Check.Name}}",
+          "PAGERDUTY_STATUS_MAP={"info":[130,10],"error":[4]}"
         ],
         "timeout": 10,
         "filters": [
@@ -121,7 +122,7 @@ The option accepts a JSON document containing the mapping information. Here's an
 }
 ```
 
-The valid PagerDuty severities are the following:
+The valid [PagerDuty alert severity levels][5] are the following:
 * `info`
 * `warning`
 * `critical`
@@ -135,3 +136,4 @@ See https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
 [2]: https://www.pagerduty.com/ 
 [3]: https://docs.sensu.io/sensu-go/5.0/reference/handlers/#how-do-sensu-handlers-work
 [4]: https://github.com/sensu/sensu-pagerduty-handler/releases
+[5]: https://support.pagerduty.com/docs/dynamic-notifications#section-eventalert-severity-levels

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Example Sensu Go handler definition:
         "command": "sensu-pagerduty-handler",
         "env_vars": [
           "PAGERDUTY_TOKEN=SECRET",
+          "PAGERDUTY_DEDUP_KEY"
         ],
         "timeout": 10,
         "filters": [
@@ -73,12 +74,20 @@ Usage:
   sensu-pagerduty-handler [flags]
 
 Flags:
-  -h, --help           help for sensu-pagerduty-handler
-  -t, --token string   The PagerDuty V2 API authentication token, use default from PAGERDUTY_TOKEN env var
-
+  -d, --dedup-key string            The Sensu event label specifying the PagerDuty V2 API deduplication key, use default from PAGERDUTY_DEDUP_KEY env var
+  -k, --dedup-key-template string   The PagerDuty V2 API deduplication key template, use default from PAGERDUTY_DEDUP_KEY_TEMPLATE env var
+  -h, --help                        help for sensu-pagerduty-handler
+  -t, --token string                The PagerDuty V2 API authentication token, use default from PAGERDUTY_TOKEN env var
 ```
 
 **Note:** Make sure to set the `PAGERDUTY_TOKEN` environment variable for sensitive credentials in production to prevent leaking into system process table. Please remember command arguments can be viewed by unprivileged users using commands such as `ps` or `top`. The `--token` argument is provided as an override primarily for testing purposes. 
+
+### Deduplication Key Priority
+The deduplication key is determined using the following priority:
+1. --dedup-key  --  specifies the entity label containing the key
+1. --dedup-key-template  --  a template containing the values
+1. the default value containing the entity and check names
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Example Sensu Go handler definition:
         "command": "sensu-pagerduty-handler",
         "env_vars": [
           "PAGERDUTY_TOKEN=SECRET",
-          "PAGERDUTY_DEDUP_KEY"
+          "PAGERDUTY_DEDUP_KEY",
+          "PAGERDUTY_STATUS_MAP"
         ],
         "timeout": 10,
         "filters": [
@@ -77,17 +78,54 @@ Flags:
   -d, --dedup-key string            The Sensu event label specifying the PagerDuty V2 API deduplication key, use default from PAGERDUTY_DEDUP_KEY env var
   -k, --dedup-key-template string   The PagerDuty V2 API deduplication key template, use default from PAGERDUTY_DEDUP_KEY_TEMPLATE env var
   -h, --help                        help for sensu-pagerduty-handler
+  -s, --status-map string           The status map used to translate a Sensu check status to a PagerDuty severity, use default from PAGERDUTY_STATUS_MAP env var
   -t, --token string                The PagerDuty V2 API authentication token, use default from PAGERDUTY_TOKEN env var
 ```
 
 **Note:** Make sure to set the `PAGERDUTY_TOKEN` environment variable for sensitive credentials in production to prevent leaking into system process table. Please remember command arguments can be viewed by unprivileged users using commands such as `ps` or `top`. The `--token` argument is provided as an override primarily for testing purposes. 
 
 ### Deduplication Key Priority
+
 The deduplication key is determined using the following priority:
 1. --dedup-key  --  specifies the entity label containing the key
 1. --dedup-key-template  --  a template containing the values
 1. the default value containing the entity and check names
 
+### PagerDuty Severity Mapping
+
+Optionally you can provide mapping information between the Sensu check status and the PagerDuty incident severity.
+To provide the mapping you need to use the `--status-map` command line option or the `PAGERDUTY_STATUS_MAP` environment variable.
+The option accepts a JSON document containing the mapping information. Here's an example of the JSON document:
+
+```json
+{
+    "info": [
+        0,
+        1
+    ],
+    "warning": [
+        2
+    ],
+    "critical:": [
+        3
+    ],
+    "error": [
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+    ]
+}
+```
+
+The valid PagerDuty severities are the following:
+* `info`
+* `warning`
+* `critical`
+* `error`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example Sensu Go handler definition:
           "PAGERDUTY_TOKEN=SECRET",
           "PAGERDUTY_DEDUP_KEY=SENSU_EVENT_LABEL",
           "PAGERDUTY_DEDUP_KEY_TEMPLATE={{.Entity.Name}}-{{.Check.Name}}",
-          "PAGERDUTY_STATUS_MAP={"info":[130,10],"error":[4]}"
+          "PAGERDUTY_STATUS_MAP={\"info\":[130,10],\"error\":[4]}"
         ],
         "timeout": 10,
         "filters": [

--- a/event.json
+++ b/event.json
@@ -1,4 +1,5 @@
 {
+  "timestamp": 1561246706000,
   "entity": {
     "entity_class": "agent",
     "system": {
@@ -58,7 +59,9 @@
     "metadata": {
       "name": "webserver01",
       "namespace": "default",
-      "labels": null,
+      "labels": {
+        "someLabel": "one hell of a deduplication key"
+      },
       "annotations": null
     }
   },
@@ -103,7 +106,7 @@
     "issued": 1542667666,
     "output": "example output",
     "state": "failing",
-    "status": 1,
+    "status": 2,
     "total_state_change": 0,
     "last_ok": 0,
     "occurrences": 1,

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ var (
 			Env:       "PAGERDUTY_STATUS_MAP",
 			Argument:  "status-map",
 			Shorthand: "s",
-			Usage:     "The status map used to translate a Sensu check status to a PagerDuty severity",
+			Usage:     "The status map used to translate a Sensu check status to a PagerDuty severity, use default from PAGERDUTY_STATUS_MAP env var",
 			Value:     &config.statusMapJson,
 			Default:   "",
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	eventWithStatus = corev2.Event{
+		Check: &corev2.Check{
+			Status: 10,
+		},
+	}
+)
+
+func Test_ParseStatusMap_Success(t *testing.T) {
+	json := "{\"info\":[130,10],\"error\":[4]}"
+
+	statusMap, err := parseStatusMap(json)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(statusMap))
+	assert.Equal(t, "info", statusMap[130])
+	assert.Equal(t, "info", statusMap[10])
+	assert.Equal(t, "error", statusMap[4])
+}
+
+func Test_ParseStatusMap_EmptyStatus(t *testing.T) {
+	json := "{\"info\":[130,10],\"error\":[]}"
+
+	statusMap, err := parseStatusMap(json)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(statusMap))
+	assert.Equal(t, "info", statusMap[130])
+	assert.Equal(t, "info", statusMap[10])
+	assert.Equal(t, "", statusMap[4])
+}
+
+func Test_ParseStatusMap_InvalidJson(t *testing.T) {
+	json := "{\"info\":[130,10],\"error:[]}"
+
+	statusMap, err := parseStatusMap(json)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "unexpected end of JSON input")
+	assert.Nil(t, statusMap)
+}
+
+func Test_ParseStatusMap_InvalidSeverity(t *testing.T) {
+	json := "{\"info\":[130,10],\"invalid\":[4]}"
+
+	statusMap, err := parseStatusMap(json)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "invalid pagerduty severity: invalid")
+	assert.Nil(t, statusMap)
+}
+
+func Test_GetPagerDutySeverity_Success(t *testing.T) {
+	statusMapJson := "{\"info\":[130,10],\"error\":[4]}"
+
+	eventWithStatus.Check.Status = 10
+	pagerDutySeverity, err := getPagerDutySeverity(&eventWithStatus, statusMapJson)
+	assert.Nil(t, err)
+	assert.Equal(t, "info", pagerDutySeverity)
+}
+
+func Test_GetPagerDutySeverity_NoStatusMapHighStatus(t *testing.T) {
+	eventWithStatus.Check.Status = 3
+	pagerDutySeverity, err := getPagerDutySeverity(&eventWithStatus, "")
+	assert.Nil(t, err)
+	assert.Equal(t, "warning", pagerDutySeverity)
+}
+
+func Test_GetPagerDutySeverity_NoStatusMapLowStatus(t *testing.T) {
+	eventWithStatus.Check.Status = 2
+	pagerDutySeverity, err := getPagerDutySeverity(&eventWithStatus, "")
+	assert.Nil(t, err)
+	assert.Equal(t, "critical", pagerDutySeverity)
+}
+
+func Test_GetPagerDutySeverity_InvalidStatusMap(t *testing.T) {
+	statusMapJson := "{\"info\":[130,10],\"error\"[4]}"
+
+	eventWithStatus.Check.Status = 2
+	pagerDutySeverity, err := getPagerDutySeverity(&eventWithStatus, statusMapJson)
+	assert.NotNil(t, err)
+	assert.Empty(t, pagerDutySeverity)
+}
+
+func Test_GetPagerDutySeverity_StatusMapSeverityNotInMap(t *testing.T) {
+	statusMapJson := "{\"info\":[130,10],\"error\":[4]}"
+
+	eventWithStatus.Check.Status = 2
+	pagerDutySeverity, err := getPagerDutySeverity(&eventWithStatus, statusMapJson)
+	assert.Nil(t, err)
+	assert.Equal(t, "critical", pagerDutySeverity)
+}


### PR DESCRIPTION
Add support for PagerDuty deduplication key. The key can be specified using an event label or using a template through a command line option.

Add support for PagerDuty severity mapping using a command line argument or environment variable. In this case the severity is determined based on the check status.

Added unit tests for these two features
Updated the README.md file to document these two features