### PR TITLE
add logic to truncate check output to keep event payload below pg limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,13 @@ func manageIncident(event *corev2.Event) error {
 	if len(summary) > 1024 {
 		summary = summary[:1024]
 	}
+	log.Printf("Incident Summary: %s", summary)
+
+	// "The maximum permitted length of PG event is 512 KB. Let's limit check output to 256KB to prevent triggering a failed send"
+	if len(event.Check.Output) > 256000 {
+		log.Printf("Warning Incident Payload Truncated!")
+		event.Check.Output = "WARNING Truncated:i\n" + event.Check.Output[:256000] + "..."
+	}
 
 	pdPayload := pagerduty.V2Payload{
 		Source:    event.Entity.Name,


### PR DESCRIPTION
Pagerduty is going to start enforcing 512KB payload lmiit.  If event is larger than the 512KB limit event creation attempt will get http error response.


Let's limit event.Check.Output to 256KB as a way to ensure users don't bounce messages.

Logic added here truncates the check output, and provides a prefix and suffix string to indicated output has been truncated