### PR TITLE
Summary Changes, Readme Fixes, DedupKey Changes

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -55,4 +55,4 @@ builds:
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   -  "entity.system.os == 'windows'"
-  -  "entity.system.arch == 'amd64'"
+  -  "entity.system.arch == '386'"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,15 @@
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod tidy
 builds:
   # List of builds
   - # First Build
     env:
     - CGO_ENABLED=0
     main: main.go
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
     # Set the binary output location to bin/ so archive will comply with Sensu Go Asset structure
     binary: bin/{{ .ProjectName }}
     goos:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added --summaryTemplate to allow for custom summary
+- Version ldflags for goreleaser
+- Plugin Config keyspace to support annotations
+
+### Changed
+- Set default of --dedup-key-template to remove hard-coded default
+- Fixed Bonsai definition for Windows 386
+- Updated README
+
+### Removed
+- Removed --dedup-key now that keyspace is added for annotations to set --dedup-key-template
+
 ## [1.2.0] - 2020-02-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Available Commands:
 Flags:
   -t, --token string                The PagerDuty V2 API authentication token, can be set with PAGERDUTY_TOKEN
   -k, --dedup-key-template string   The PagerDuty V2 API deduplication key template, can be set with PAGERDUTY_DEDUP_KEY_TEMPLATE (default "{{.Entity.Name}}-{{.Check.Name}}")
-  -S, --summary-template string     The template for the alert summary, can be set with PAGERDUTY_SUMMARY_TEMPLATE
-  -s, --status-map string           The status map used to translate a Sensu check status to a PagerDuty severity, can be set with PAGERDUTY_STATUS_MAP (default "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}")
+  -S, --summary-template string     The template for the alert summary, can be set with PAGERDUTY_SUMMARY_TEMPLATE (default "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}")
+  -s, --status-map string           The status map used to translate a Sensu check status to a PagerDuty severity, can be set with PAGERDUTY_STATUS_MAP
   -h, --help                        help for sensu-pagerduty-handler
 
 Use "sensu-pagerduty-handler [command] --help" for more information about a command.

--- a/README.md
+++ b/README.md
@@ -1,103 +1,70 @@
 # Sensu PagerDuty Handler
 
 [![Bonsai Asset Badge](https://img.shields.io/badge/Sensu%20PagerDuty%20Handler-Download%20Me-brightgreen.svg?colorB=89C967&logo=sensu)](https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler)
+![Go Test](https://github.com/sensu/sensu-pagerduty-handler/workflows/Go%20Test/badge.svg)
+![goreleaser](https://github.com/sensu/sensu-pagerduty-handler/workflows/goreleaser/badge.svg)
+
+# Sensu PagerDuty Handler
+
+## Table of Contents
+- [Overview](#overview)
+- [Usage examples](#usage-examples)
+  - [Help](#help)
+  - [Deduplication Key](#deduplication-key)
+  - [PagerDuty Severity Mapping](#pagerduty-severity-mapping)
+- [Configuration](#configuration)
+  - [Asset registration](#asset-registration)
+  - [Handler definition](#handler-definition)
+  - [Environment Variables](#environment-variables)
+  - [Argument Annotations](#argument-annotations)
+  - [Proxy support](#proxy-support)
+- [Installation from source](#installation-from-source)
+- [Contributing](#contributing)
+
+## Overview
 
 The Sensu PagerDuty Handler is a [Sensu Event Handler][3] which manages
 [PagerDuty][2] incidents, for alerting operators. With this handler,
 [Sensu][1] can trigger and resolve PagerDuty incidents.
 
-## Installation
-
-Download the latest version of the sensu-pagerduty-handler from [releases][4],
-or create an executable script from this source.
-
-From the local path of the sensu-pagerduty-handler repository:
-```
-go build -o /usr/local/bin/sensu-pagerduty-handler
-```
-
-## Configuration
-
-Example Sensu handler definition:
-
-```json
-{
-    "api_version": "core/v2",
-    "type": "Handler",
-    "metadata": {
-        "namespace": "default",
-        "name": "pagerduty"
-    },
-    "spec": {
-        "type": "pipe",
-        "command": "sensu-pagerduty-handler",
-        "env_vars": [
-          "PAGERDUTY_TOKEN=SECRET",
-          "PAGERDUTY_DEDUP_KEY=SENSU_EVENT_LABEL",
-          "PAGERDUTY_DEDUP_KEY_TEMPLATE={{.Entity.Name}}-{{.Check.Name}}",
-          "PAGERDUTY_STATUS_MAP={\"info\":[130,10],\"error\":[4]}"
-        ],
-        "timeout": 10,
-        "filters": [
-            "is_incident"
-        ]
-    }
-}
-```
-
-Example Sensu check definition:
-
-```json
-{
-    "api_version": "core/v2",
-    "type": "CheckConfig",
-    "metadata": {
-        "namespace": "default",
-        "name": "dummy-app-healthz"
-    },
-    "spec": {
-        "command": "check-http -u http://localhost:8080/healthz",
-        "subscriptions":[
-            "dummy"
-        ],
-        "publish": true,
-        "interval": 10,
-        "handlers": [
-            "pagerduty"
-        ]
-    }
-}
-```
-
 ## Usage Examples
 
-Help:
+### Help
 ```
+The Sensu Go PagerDuty handler for incident management
+
 Usage:
   sensu-pagerduty-handler [flags]
+  sensu-pagerduty-handler [command]
+
+Available Commands:
+  help        Help about any command
+  version     Print the version number of this plugin
 
 Flags:
-  -d, --dedup-key string            The Sensu event label specifying the PagerDuty V2 API deduplication key, use default from PAGERDUTY_DEDUP_KEY env var
-  -k, --dedup-key-template string   The PagerDuty V2 API deduplication key template, use default from PAGERDUTY_DEDUP_KEY_TEMPLATE env var
+  -t, --token string                The PagerDuty V2 API authentication token, can be set with PAGERDUTY_TOKEN
+  -k, --dedup-key-template string   The PagerDuty V2 API deduplication key template, can be set with PAGERDUTY_DEDUP_KEY_TEMPLATE (default "{{.Entity.Name}}-{{.Check.Name}}")
+  -S, --summary-template string     The template for the alert summary, can be set with PAGERDUTY_SUMMARY_TEMPLATE
+  -s, --status-map string           The status map used to translate a Sensu check status to a PagerDuty severity, can be set with PAGERDUTY_STATUS_MAP (default "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}")
   -h, --help                        help for sensu-pagerduty-handler
-  -s, --status-map string           The status map used to translate a Sensu check status to a PagerDuty severity, use default from PAGERDUTY_STATUS_MAP env var
-  -t, --token string                The PagerDuty V2 API authentication token, use default from PAGERDUTY_TOKEN env var
+
+Use "sensu-pagerduty-handler [command] --help" for more information about a command.
+
 ```
 
-**Note:** Make sure to set the `PAGERDUTY_TOKEN` environment variable for sensitive credentials in production to prevent leaking into system process table. Please remember command arguments can be viewed by unprivileged users using commands such as `ps` or `top`. The `--token` argument is provided as an override primarily for testing purposes. 
+### Deduplication Key
 
-### Deduplication Key Priority
-
-The deduplication key is determined using the following priority:
-1. --dedup-key  --  specifies the entity label containing the key
-1. --dedup-key-template  --  a template containing the values
-1. the default value containing the entity and check names
+The deduplication key is determined via the `--dedup-key-template` argument.  It
+is a Golang template containing the event values and defaults to
+`{{.Entity.Name}}-{{.Check.Name}}`.
 
 ### PagerDuty Severity Mapping
 
-Optionally you can provide mapping information between the Sensu check status and the PagerDuty incident severity.
-To provide the mapping you need to use the `--status-map` command line option or the `PAGERDUTY_STATUS_MAP` environment variable.
-The option accepts a JSON document containing the mapping information. Here's an example of the JSON document:
+Optionally you can provide mapping information between the Sensu check status
+and the PagerDuty incident severity. To provide the mapping you need to use the
+`--status-map` command line option or the `PAGERDUTY_STATUS_MAP` environment
+variable.  The option accepts a JSON document containing the mapping
+information. Here's an example of the JSON document:
 
 ```json
 {
@@ -129,12 +96,122 @@ The valid [PagerDuty alert severity levels][5] are the following:
 * `critical`
 * `error`
 
+## Configuration
+### Sensu Go
+#### Asset registration
+
+[Sensu Assets][6] are the best way to make use of this plugin. If you're not
+using an asset, please consider doing so! If you're using sensuctl 5.13 with
+Sensu Backend 5.13 or later, you can use the following command to add the asset:
+
+```
+sensuctl asset add sensu/sensu-pagerduty-handler
+```
+
+If you're using an earlier version of sensuctl, you can find the asset on the
+[Bonsai Asset Index][7].
+
+#### Handler definition
+
+```yml
+---
+type: Handler
+api_version: core/v2
+metadata:
+  name: pagerduty
+  namespace: default
+spec:
+  type: pipe
+  command: sensu-pagerduty-handler
+  timeout: 10
+  runtime_assets:
+  - sensu/sensu-pagerduty-handler
+  filters:
+  - is_incident
+  secrets:
+  - name: PAGERDUTY_TOKEN
+    secret: pagerduty_authtoken
+```
+
+#### Environment Variables
+
+Most arguments for this handler are available to be set via environment
+variables.  However, any arguments specified directly on the command line
+override the corresponding environment variable.
+
+|Argument            |Environment Variable        |
+|--------------------|----------------------------|
+|--token             |PAGERDUTY_TOKEN             |
+|--summary-template  |PAGERDUTY_SUMMARY_TEMPLATE  |
+|--dedup-key-template|PAGERDUTY_DEDUP_KEY_TEMPLATE|
+|--status-map        |PAGERDUTY_STATUS_MAP        |
+
+**Security Note:** Care should be taken to not expose the auth token for this
+handler by specifying it on the command line or by directly setting the
+environment variable in the handler definition.  It is suggested to make use of
+[secrets management][8] to surface it as an environment variable.  The handler
+definition above references it as a secret.  Below is an example secrets
+definition that make use of the built-in [env secrets provider][9].
+
+```yml
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: pagerduty_token
+spec:
+  provider: env
+  id: PAGERDUTY_TOKEN
+```
+
+#### Argument Annotations
+
+All arguments for this handler are tunable on a per entity or check basis based
+on annotations.  The annotations keyspace for this handler is
+`sensu.io/plugins/sensu-opsgenie-handler/config`.
+
+###### Examples
+
+To change the token argument for a particular check, for that checks's metadata
+add the following:
+
+```yml
+type: CheckConfig
+api_version: core/v2
+metadata:
+  annotations:
+    sensu.io/plugins/sensu-pagerduty-handler/config/token: abcde12345fabcd67890efabc12345de
+[...]
+```
+
+#### Proxy Support
+
+This handler supports the use of the environment variables HTTP_PROXY,
+HTTPS_PROXY, and NO_PROXY (or the lowercase versions thereof). HTTPS_PROXY takes
+precedence over HTTP_PROXY for https requests.  The environment values may be
+either a complete URL or a "host[:port]", in which case the "http" scheme is
+assumed.
+
+## Installation from source
+
+Download the latest version of the sensu-pagerduty-handler from [releases][4],
+or create an executable script from this source.
+
+From the local path of the sensu-pagerduty-handler repository:
+```
+go build -o /usr/local/bin/sensu-pagerduty-handler
+```
+
 ## Contributing
 
 See https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
 
 [1]: https://github.com/sensu/sensu-go
-[2]: https://www.pagerduty.com/ 
+[2]: https://www.pagerduty.com/
 [3]: https://docs.sensu.io/sensu-go/5.0/reference/handlers/#how-do-sensu-handlers-work
 [4]: https://github.com/sensu/sensu-pagerduty-handler/releases
 [5]: https://support.pagerduty.com/docs/dynamic-notifications#section-eventalert-severity-levels
+[6]: https://docs.sensu.io/sensu-go/latest/reference/assets/
+[7]: https://bonsai.sensu.io/sensu/sensu-pagerduty-handler
+[8]: https://docs.sensu.io/sensu-go/latest/guides/secrets-management/
+[9]: https://docs.sensu.io/sensu-go/latest/guides/secrets-management/#use-env-for-secrets-management

--- a/main_test.go
+++ b/main_test.go
@@ -94,3 +94,12 @@ func Test_GetPagerDutySeverity_StatusMapSeverityNotInMap(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "critical", pagerDutySeverity)
 }
+
+func Test_GetPagerDutyDedupKey(t *testing.T) {
+	event := corev2.FixtureEvent("foo", "bar")
+	config.dedupKeyTemplate = "{{.Entity.Name}}-{{.Check.Name}}"
+
+	dedupKey, err := getPagerDutyDedupKey(event)
+	assert.Nil(t, err)
+	assert.Equal(t, "foo-bar", dedupKey)
+}


### PR DESCRIPTION
Added --summaryTemplate to allow for custom summary
Added version ldflags for goreleaser
Added plugin Config keyspace to support annotations
Set default of --dedup-key-template to remove hard-coded default
Fixed Bonsai definition for Windows 386
Updated README
Removed --dedup-key now that keyspace is added for annotations to set --dedup-key-template

Closes #26 
Closes #23 
Closes #20 
Closes #12 
Supersedes #21 
Supersedes #22 

Signed-off-by: Todd Campbell <todd@sensu.io>