### PR TITLE
Updates to allow for use of additional PD-CEF fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Add `--client-name` and `--sensu-base-url`. If provided, these options add a link to the Sensu dashboard from the
+  Pagerduty Alert.
+- Add `--link-annotations` option. If set, this option will any links provided in the check or entity annotations as
+  links in the Pagerduty Event.
+- Add ability to template additional PD-CEF Fields from Sensu event data:
+  - Add `--use-event-timestamp` option. If set this option will set the `Timestamp` field to the
+    timestamp of the Sensu event.
+  - Add `--class-template`, `--group-template` and `--component-template` option. If provided, this option allows for
+    the `Class`, `Group` and `Component` PD-CEF fields to be templated from Sensu event data. Note the
+    `Component` field is set to the Sensu events `.Check.Name` by default if no template is provided to retain
+    compatibility.
+
 ## 2.6.0 - 2024-02-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -47,17 +47,24 @@ Available Commands:
 
 Flags:
   -e, --alternate-endpoint string   The endpoint to use to send the PagerDuty events, can be set with PAGERDUTY_ALTERNATE_ENDPOINT
+      --class-template string       Template for PD-CEF class field, can be set with PAGERDUTY_CLASS_TEMPLATE
+      --client-name string          Name for the client, this will appear in Pagerduty when events are logged (default "Sensu")
+      --component-template string   Template for PD-CEF component field, can be set with PAGERDUTY_COMPONENT_TEMPLATE
       --contact-routing             Enable contact routing
   -k, --dedup-key-template string   The PagerDuty V2 API deduplication key template, can be set with PAGERDUTY_DEDUP_KEY_TEMPLATE (default "{{.Entity.Name}}-{{.Check.Name}}")
       --details-format string       The format of the details output ('string' or 'json'), can be set with PAGERDUTY_DETAILS_FORMAT (default "string")
   -d, --details-template string     The template for the alert details, can be set with PAGERDUTY_DETAILS_TEMPLATE (default full event JSON)
+      --group-template string       Template for PD-CEF group field, can be set with PAGERDUTY_GROUP_TEMPLATE
   -h, --help                        help for sensu-pagerduty-handler
+  -l, --link-annotations            Add links for any annotations that are a URL
+  -u, --sensu-base-url string       Base URL for sensu. The handler will add a link to the event using this
   -s, --status-map string           The status map used to translate a Sensu check status to a PagerDuty severity, can be set with PAGERDUTY_STATUS_MAP
   -S, --summary-template string     The template for the alert summary, can be set with PAGERDUTY_SUMMARY_TEMPLATE (default "{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}")
       --team string                 Envvar name for pager team(alphanumeric and underscores) holding PagerDuty V2 API authentication token, can be set with PAGERDUTY_TEAM
       --team-suffix string          Pager team suffix string to append if missing from team name, can be set with PAGERDUTY_TEAM_SUFFIX (default "_pagerduty_token")
       --timeout uint                The maximum amount of time in seconds to wait for the event to be created, can be set with PAGERDUTY_TIMEOUT (default 30)
   -t, --token string                The PagerDuty V2 API authentication token, can be set with PAGERDUTY_TOKEN
+  -T, --use-event-timestamp         Use the timestamp from the Sensu event for the PD-CEF timestamp field
 
 Use "sensu-pagerduty-handler [command] --help" for more information about a command.
 ```
@@ -159,9 +166,13 @@ override the corresponding environment variable.
 | Argument             | Environment Variable         |
 |----------------------|------------------------------|
 | --alternate-endpoint | PAGERDUTY_ALTERNATE_ENDPOINT |
+| --class-template     | PAGERDUTY_CLASS_TEMPLATE     |
+| --component-template | PAGERDUTY_COMPONENT_TEMPLATE |
+| --group-template     | PAGERDUTY_GROUP_TEMPLATE     | 
 | --dedup-key-template | PAGERDUTY_DEDUP_KEY_TEMPLATE |
 | --details-template   | PAGERDUTY_DETAILS_TEMPLATE   |
 | --details-format     | PAGERDUTY_DETAILS_FORMAT     |
+| --sensu-base-url     | PAGERDUTY_SENSU_BASE_URL     |
 | --status-map         | PAGERDUTY_STATUS_MAP         |
 | --summary-template   | PAGERDUTY_SUMMARY_TEMPLATE   |
 | --team               | PAGERDUTY_TEAM               |

--- a/main.go
+++ b/main.go
@@ -588,7 +588,12 @@ func getSummary(event *corev2.Event) (string, error) {
 func getTimestamp(event *corev2.Event) string {
 	timestamp := ""
 	if config.useEventTimestamp {
-		timestamp = time.Unix(event.Timestamp, 0).Format(time.RFC3339)
+		sec := event.Timestamp / 1000
+		nsec := (event.Timestamp % 1000) * int64(time.Millisecond)
+		// Convert the Sensu event timestamp to a time.Time object
+		t := time.Unix(sec, nsec)
+		// Format the time in the desired layout
+		timestamp = t.Format("2006-01-02T15:04:05.000-0700")
 	}
 
 	return timestamp

--- a/main_test.go
+++ b/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	corev2 "github.com/sensu/core/v2"
 	"github.com/stretchr/testify/assert"
@@ -200,22 +202,24 @@ func Test_GetDetailsObj(t *testing.T) {
 	config.detailsFormat = "json"
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			config.detailsTemplate = test.detailsTemplate
-			details, err := getDetails(event)
-			if test.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, details)
-				detailMap, ok := details.(map[string]interface{})
-				assert.True(t, ok)
-				assert.Equal(t, "entity-name", detailMap["entity"])
-				assert.Equal(t, "check-name", detailMap["check"])
-				assert.Equal(t, "default", detailMap["namespace"])
-				assert.Equal(t, event.GetUUID().String(), detailMap["id"])
-			}
-		})
+		t.Run(
+			test.name, func(t *testing.T) {
+				config.detailsTemplate = test.detailsTemplate
+				details, err := getDetails(event)
+				if test.expectError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, details)
+					detailMap, ok := details.(map[string]interface{})
+					assert.True(t, ok)
+					assert.Equal(t, "entity-name", detailMap["entity"])
+					assert.Equal(t, "check-name", detailMap["check"])
+					assert.Equal(t, "default", detailMap["namespace"])
+					assert.Equal(t, event.GetUUID().String(), detailMap["id"])
+				}
+			},
+		)
 	}
 }
 
@@ -305,17 +309,19 @@ func Test_checkArgs(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config = tt.config
+		t.Run(
+			tt.name, func(t *testing.T) {
+				config = tt.config
 
-			err := checkArgs(tt.args.event)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("checkArgs() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err != nil && err.Error() != tt.wantErrMsg {
-				t.Errorf("checkArgs() error msg = %v, want %v", err, tt.wantErrMsg)
-			}
-		})
+				err := checkArgs(tt.args.event)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("checkArgs() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if err != nil && err.Error() != tt.wantErrMsg {
+					t.Errorf("checkArgs() error msg = %v, want %v", err, tt.wantErrMsg)
+				}
+			},
+		)
 		config = originalConfig
 	}
 }
@@ -332,11 +338,13 @@ func Test_handleEvent(t *testing.T) {
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := handleEvent(tt.args.event); (err != nil) != tt.wantErr {
-				t.Errorf("handleEvent() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				if err := handleEvent(tt.args.event); (err != nil) != tt.wantErr {
+					t.Errorf("handleEvent() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			},
+		)
 	}
 }
 
@@ -352,11 +360,13 @@ func Test_handleEventContactRouting(t *testing.T) {
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := handleEventContactRouting(tt.args.event); (err != nil) != tt.wantErr {
-				t.Errorf("handleEventContactRouting() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				if err := handleEventContactRouting(tt.args.event); (err != nil) != tt.wantErr {
+					t.Errorf("handleEventContactRouting() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			},
+		)
 	}
 }
 
@@ -373,11 +383,13 @@ func Test_handleEventForContact(t *testing.T) {
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := handleEventForContact(tt.args.event, tt.args.contact); (err != nil) != tt.wantErr {
-				t.Errorf("handleEventForContact() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				if err := handleEventForContact(tt.args.event, tt.args.contact); (err != nil) != tt.wantErr {
+					t.Errorf("handleEventForContact() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			},
+		)
 	}
 }
 
@@ -393,11 +405,13 @@ func Test_getContacts(t *testing.T) {
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getContacts(tt.args.event); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getContacts() = %v, want %v", got, tt.want)
-			}
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				if got := getContacts(tt.args.event); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("getContacts() = %v, want %v", got, tt.want)
+				}
+			},
+		)
 	}
 }
 
@@ -414,15 +428,379 @@ func Test_getContactToken(t *testing.T) {
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := getContactToken(tt.args.contact)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getContactToken() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("getContactToken() = %v, want %v", got, tt.want)
-			}
-		})
+		t.Run(
+			tt.name, func(t *testing.T) {
+				got, err := getContactToken(tt.args.contact)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("getContactToken() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if got != tt.want {
+					t.Errorf("getContactToken() = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func Test_getTimestamp(t *testing.T) {
+	originalConfig := config
+
+	now := time.Now()
+
+	type args struct {
+		event *corev2.Event
+	}
+	tests := []struct {
+		config HandlerConfig
+		name   string
+		args   args
+		want   string
+	}{
+		{
+			config: HandlerConfig{useEventTimestamp: false},
+			name:   "dont-use-event-timestamp",
+			args:   args{event: &eventWithStatus},
+			want:   "",
+		},
+		{
+			config: HandlerConfig{useEventTimestamp: true},
+			name:   "use-event-timestamp",
+			args:   args{event: &corev2.Event{Timestamp: now.Unix()}},
+			want:   now.Format(time.RFC3339),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				config = tt.config
+				assert.Equalf(t, tt.want, getTimestamp(tt.args.event), "getTimestamp(%v)", tt.args.event)
+			},
+		)
+		config = originalConfig
+	}
+}
+
+func Test_getGroup(t *testing.T) {
+	originalConfig := config
+
+	type args struct {
+		event *corev2.Event
+	}
+	tests := []struct {
+		name    string
+		config  HandlerConfig
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "invalid template returns error",
+			config: HandlerConfig{groupTemplate: "{{.BadVar}}"},
+			args:   args{event: &eventWithStatus},
+			want:   "",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Error(t, err)
+			},
+		},
+		{
+			name: "empty result returned when no group template is defined",
+			args: args{event: &eventWithStatus},
+			want: "",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Nil(t, err)
+			},
+		},
+		{
+			name:   "valid template returns correct result and no error",
+			config: HandlerConfig{groupTemplate: "{{.Check.Labels.group}}"},
+			args: args{
+				event: &corev2.Event{
+					Check: &corev2.Check{
+						ObjectMeta: corev2.
+							ObjectMeta{Labels: map[string]string{"group": "foobar"}},
+					},
+				},
+			},
+			want: "foobar",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Nil(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				config = tt.config
+				got, err := getGroup(tt.args.event)
+				if !tt.wantErr(t, err, fmt.Sprintf("getGroup(%v)", tt.args.event)) {
+					return
+				}
+				assert.Equalf(t, tt.want, got, "getGroup(%v)", tt.args.event)
+			},
+		)
+		config = originalConfig
+	}
+}
+
+func Test_isLink(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid http link is link",
+			args: args{s: "http://foobar.net/one/two/three.html"},
+			want: true,
+		},
+		{
+			name: "valid http link is link",
+			args: args{s: "https://foobar.net"},
+			want: true,
+		},
+		{
+			name: "invalid link is not link",
+			args: args{s: "this is not a link"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				assert.Equalf(t, tt.want, isLink(tt.args.s), "isLink(%v)", tt.args.s)
+			},
+		)
+	}
+}
+
+func Test_getComponent(t *testing.T) {
+	originalConfig := config
+
+	type args struct {
+		event *corev2.Event
+	}
+	tests := []struct {
+		name    string
+		config  HandlerConfig
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "bad template returns error",
+			config: HandlerConfig{componentTemplate: "{{.BadVar}}"},
+			args:   args{event: &eventWithStatus},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Error(t, err)
+			},
+			want: "",
+		},
+		{
+			name:   "no result returned when component template not set",
+			config: HandlerConfig{componentTemplate: ""},
+			args:   args{event: &corev2.Event{Check: &corev2.Check{ObjectMeta: corev2.ObjectMeta{Name: "test-check"}}}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Nil(t, err)
+			},
+			want: "test-check",
+		},
+		{
+			name:   "good template",
+			config: HandlerConfig{componentTemplate: "{{.Entity.Labels.component}}"},
+			args: args{
+				event: &corev2.Event{
+					Entity: &corev2.Entity{
+						ObjectMeta: corev2.ObjectMeta{Labels: map[string]string{"component": "component"}},
+					},
+				},
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Nil(t, err)
+			},
+			want: "component",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				config = tt.config
+				got, err := getComponent(tt.args.event)
+				if !tt.wantErr(t, err, fmt.Sprintf("getComponent(%v)", tt.args.event)) {
+					return
+				}
+				assert.Equalf(t, tt.want, got, "getComponent(%v)", tt.args.event)
+			},
+		)
+		config = originalConfig
+	}
+}
+
+func Test_getClass(t *testing.T) {
+	originalConfig := config
+
+	type args struct {
+		event *corev2.Event
+	}
+	tests := []struct {
+		name    string
+		config  HandlerConfig
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "bad template",
+			config: HandlerConfig{classTemplate: "{{.BadVar}}"},
+			args:   args{event: &eventWithStatus},
+			want:   "",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Error(t, err)
+			},
+		},
+		{
+			name:   "no template",
+			config: HandlerConfig{classTemplate: ""},
+			args:   args{event: &eventWithStatus},
+			want:   "",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Nil(t, err)
+			},
+		},
+		{
+			name:   "good template",
+			config: HandlerConfig{classTemplate: "{{.Check.Name}}"},
+			args: args{
+				event: &corev2.Event{
+					Check: &corev2.Check{
+						ObjectMeta: corev2.
+							ObjectMeta{Name: "some-check"},
+					},
+				},
+			},
+			want: "some-check",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.Nil(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				config = tt.config
+				got, err := getClass(tt.args.event)
+				if !tt.wantErr(t, err, fmt.Sprintf("getClass(%v)", tt.args.event)) {
+					return
+				}
+				assert.Equalf(t, tt.want, got, "getClass(%v)", tt.args.event)
+			},
+		)
+		config = originalConfig
+	}
+}
+
+func Test_getClientUrl(t *testing.T) {
+	originalConfig := config
+	type args struct {
+		event *corev2.Event
+	}
+	tests := []struct {
+		name   string
+		config HandlerConfig
+		args   args
+		want   string
+	}{
+		{
+			name: "no base url defined",
+			args: args{event: &eventWithStatus},
+			want: "",
+		},
+		{
+			name:   "base url defined",
+			config: HandlerConfig{sensuBaseUrl: "https://test-sensu.some-company.com/"},
+			args: args{
+				event: &corev2.Event{
+					ObjectMeta: corev2.ObjectMeta{Namespace: "test-namespace"},
+					Entity:     &corev2.Entity{ObjectMeta: corev2.ObjectMeta{Name: "test-entity"}},
+					Check:      &corev2.Check{ObjectMeta: corev2.ObjectMeta{Name: "test-check"}},
+				},
+			},
+			want: "https://test-sensu.some-company.com/c/~/n/test-namespace/events/test-entity/test-check",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				config = tt.config
+				assert.Equalf(t, tt.want, getClientUrl(tt.args.event), "getClientUrl(%v)", tt.args.event)
+			},
+		)
+		config = originalConfig
+	}
+}
+
+func Test_getLinks(t *testing.T) {
+	originalConfig := config
+	type args struct {
+		event *corev2.Event
+	}
+	tests := []struct {
+		name   string
+		config HandlerConfig
+		args   args
+		want   []interface{}
+	}{
+		{
+			name: "no links",
+			args: args{event: &eventWithStatus},
+			want: []interface{}{},
+		},
+		{
+			name:   "check and entity links",
+			config: HandlerConfig{linkAnnotations: true},
+			args: args{
+				event: &corev2.Event{
+					Check: &corev2.Check{
+						ObjectMeta: corev2.
+							ObjectMeta{
+							Annotations: map[string]string{
+								"link":       "https://123.foobar.com/somepage",
+								"not-a-link": "nolink",
+							},
+						},
+					},
+					Entity: &corev2.Entity{
+						ObjectMeta: corev2.ObjectMeta{
+							Annotations: map[string]string{
+								"link":       "https://123.foobar.com/somepage",
+								"not-a-link": "nolink",
+							},
+						},
+					},
+				},
+			},
+			want: []interface{}{
+				Link{
+					Text: "check link",
+					Href: "https://123.foobar.com/somepage",
+				},
+				Link{
+					Text: "entity link",
+					Href: "https://123.foobar.com/somepage",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				config = tt.config
+				assert.Equalf(t, tt.want, getLinks(tt.args.event), "getLinks(%v)", tt.args.event)
+			},
+		)
+		config = originalConfig
 	}
 }


### PR DESCRIPTION
- Add `--client-name` and `--sensu-base-url`. If provided, these options add a link to the Sensu dashboard from the Pagerduty Alert.
- Add `--link-annotations` option. If set, this option will any links provided in the check or entity annotations as links in the Pagerduty Event.
- Add ability to template additional [PD-CEF][PD-CEF] Fields from Sensu event data:
  - Add `--use-event-timestamp` option. If set this option will set the `Timestamp` field to the timestamp of the Sensu event.
  - Add `--class-template`, `--group-template` and `--component-template` option. If provided, this option allows for the `Class`, `Group` and `Component` [PD-CEF][PD-CEF] fields to be templated from Sensu event data. Note the `Component` field is set to the Sensu events `.Check.Name` by default if no template is provided to retain compatibility.

[PD-CEF]: https://support.pagerduty.com/docs/pd-cef